### PR TITLE
feat: temporarily remove password validation from sign-up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@feathersjs/rest-client": "^5.0.34",
         "@types/bcrypt": "^5.0.2",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^22.15.17",
+        "@types/node": "^22.15.32",
         "axios": "^1.9.0",
         "cross-env": "^7.0.3",
         "mocha": "^11.2.2",
@@ -1414,9 +1414,10 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
-      "version": "22.15.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
-      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
+      "version": "22.15.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz",
+      "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@feathersjs/rest-client": "^5.0.34",
     "@types/bcrypt": "^5.0.2",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^22.15.17",
+    "@types/node": "^22.15.32",
     "axios": "^1.9.0",
     "cross-env": "^7.0.3",
     "mocha": "^11.2.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+
+
 import { app } from './app'
 import { logger } from './logger'
 

--- a/src/services/users/users.hooks.ts
+++ b/src/services/users/users.hooks.ts
@@ -19,6 +19,7 @@ const checkEmailExists = async (context: HookContext) => {
   if (existingUser) {
     throw new BadRequest('This email is already registered')
   }
+  
 
   return context
 }
@@ -51,7 +52,7 @@ export const userHooks = {
     all: [schemaHooks.resolveExternal(userExternalResolver)],
     find: [authenticate('jwt')],
     get: [authenticate('jwt')],
-    create: [schemaHooks.validateData(userDataValidator), schemaHooks.resolveData(userDataResolver)],
+    create: [schemaHooks.resolveData(userDataResolver)],
     update: [authenticate('jwt')],
     patch: [authenticate('jwt')],
     remove: [authenticate('jwt')]
@@ -60,7 +61,7 @@ export const userHooks = {
     all: [],
     find: [],
     get: [],
-    create: [schemaHooks.validateData(userDataValidator), checkEmailExists, assignCodeName],
+    create: [checkEmailExists, assignCodeName],
     patch: [],
     remove: []
   }

--- a/src/services/users/users.schema.ts
+++ b/src/services/users/users.schema.ts
@@ -13,7 +13,7 @@ export const userSchema = Type.Object(
   {
     id: Type.Optional(Type.Number()),
     email: Type.String({ format: "email" }),
-    password: Type.String({ minLength: 7 }),
+    password: Type.Optional(Type.String({ minLength: 7 })),
     name: Type.String(),
     code_name_id: Type.Optional(Type.Number()),
     code_name: Type.Optional(Type.String()) // <-- Add this line
@@ -39,14 +39,12 @@ export const userExternalResolver = resolve<User, HookContext<UserService>>({
 })
 
 // Schema for creating new entries
-export const userDataSchema = Type.Pick(userSchema, ['email', 'password', 'name'], {
+export const userDataSchema = Type.Pick(userSchema, ['email', 'name'], {
   $id: 'UserData'
 })
 export type UserData = Static<typeof userDataSchema>
 export const userDataValidator = getValidator(userDataSchema, dataValidator)
-export const userDataResolver = resolve<User, HookContext<UserService>>({
-  password: passwordHash({ strategy: 'local' })
-})
+export const userDataResolver = resolve<User, HookContext<UserService>>({})
 
 // Schema for updating existing entries
 export const userPatchSchema = Type.Partial(userSchema, {


### PR DESCRIPTION
### Summary
This PR removes the password validation requirement during user registration to simplify onboarding.

### Changes
- Made `password` field optional in the user schema
- Skipped password hashing and validation in user hooks
- Dropped `NOT NULL` constraint on the `password` column in PostgreSQL
- Verified successful user creation without a password

### Note
This is a temporary adjustment and can be re-enabled when authentication flow is finalized.