### PR TITLE
implement back dating of goals

### DIFF
--- a/controller/goal_controller.js
+++ b/controller/goal_controller.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 const {Goal, User} = require('../models');
 const GOAL_STATUS = require('../constants/goalStatus');
-const {pairGoalsService, fetchIndustrySectors} = require('../services/goals');
+const {pairGoalsService, fetchIndustrySectors, backDateGoalService} = require('../services/goals');
 const RES_CODES = require('../constants/responseCodes');
 const getWeekBoundaries = require('../utils/getWeekBoundaries');
 const {apiResponse, ResponseStatusEnum} = require('../utils/apiResponse');
@@ -41,7 +41,7 @@ const createGoal = async (req, res) => {
 				status: ResponseStatusEnum.FAIL,
 				statusCode: 400,
 				message:
-          'Please complete your profile (professional info, goals info, and engagement info) before creating goals.',
+					'Please complete your profile (professional info, goals info, and engagement info) before creating goals.',
 			});
 		}
 
@@ -84,7 +84,7 @@ const createGoal = async (req, res) => {
 				status: ResponseStatusEnum.FAIL,
 				statusCode: 400,
 				message:
-          'You already have goals set for this week. You can update them if they are still pending.',
+					'You already have goals set for this week. You can update them if they are still pending.',
 			});
 		}
 
@@ -502,6 +502,26 @@ const getUserGoalsByDate = async (req, res) => {
 	}
 };
 
+const backDateGoal = async (req, res) => {
+	try {
+		await backDateGoalService();
+		return apiResponse({
+			res,
+			status: ResponseStatusEnum.SUCCESS,
+			statusCode: 200,
+			data: null,
+			message: 'All created goals during the current week were successfully back-dated',
+		});
+	} catch (error) {
+		return apiResponse({
+			res,
+			status: ResponseStatusEnum.FAIL,
+			statusCode: 500,
+			message: error || 'Server error',
+		});
+	}
+};
+
 module.exports = {
 	createGoal,
 	updateGoal,
@@ -511,4 +531,5 @@ module.exports = {
 	getUserGoalsByDate,
 	pairGoals,
 	getIndustrySectors,
+	backDateGoal,
 };

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5804,6 +5804,58 @@
           }
         }
       }
+    },
+    "/api/v1/goal/back-date": {
+      "patch": {
+        "tags": ["Goal"],
+        "summary": "Back date all goals that were created in the current week",
+
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": null
+                    }
+                  }
+                },
+                "example": {
+                  "status": "success",
+                  "message": "All created goals during the current week were successfully back-dated",
+                  "data": null
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "fail",
+                  "message": "An error occured",
+                  "data": null
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/routes/goal.js
+++ b/routes/goal.js
@@ -9,6 +9,7 @@ const {
 	getUserGoalsByDate,
 	pairGoals,
 	getIndustrySectors,
+	backDateGoal,
 } = require('../controller/goal_controller');
 
 const {authenticateToken, checkIfUserIsAdmin} = require('../middleware/auth');
@@ -17,6 +18,8 @@ const {authenticateToken, checkIfUserIsAdmin} = require('../middleware/auth');
 router.route('/').post(authenticateToken, createGoal);
 
 router.route('/industry-sector').get(authenticateToken, getIndustrySectors);
+
+router.route('/back-date').put(authenticateToken, checkIfUserIsAdmin, backDateGoal);
 
 // Get user goals with pagination
 router.route('/').get(authenticateToken, getUserGoals);

--- a/services/goals/index.js
+++ b/services/goals/index.js
@@ -182,4 +182,24 @@ const pairGoalsService = async ({date}) => {
 
 const fetchIndustrySectors = async () => IndustrySector.findAll({raw: true});
 
-module.exports = {fetchGoalsService, pairGoalsService, fetchIndustrySectors};
+const backDateGoalService = async () => {
+	const {weekStart, weekEnd} = getWeekBoundaries();
+
+	Goal.update({
+		week_start: new Date(Date.parse(weekStart) - (13 * 24 * 60 * 60 * 1000)),
+		week_end: new Date(Date.parse(weekEnd) - (13 * 24 * 60 * 60 * 1000)),
+	}, {
+		where: {
+			week_start: {
+				[Op.gte]: weekStart,
+			},
+			week_end: {
+				[Op.lte]: weekEnd,
+			},
+		},
+	});
+};
+
+module.exports = {
+	fetchGoalsService, pairGoalsService, fetchIndustrySectors, backDateGoalService,
+};


### PR DESCRIPTION
### **What does this PR do?**

It creates an endpoint that allows the admin to backdate goals that were created in the current week

---

### **What was done in this PR?**

- An endpoint was created that allows the admin only to backdate goals that fall within the current week.

---

### **How should this be tested?**

- Fetch the branch locally
- Create multiple goals as a different users
- Try creating goal for a user that already has a goal for that week, the system throws an error
- Now, login as an admin and call the backdate endpoint
`PUT /api/v1/goal/back-date`
- After the endpoint completes successfully, you should be able to create goal for the same user for that week because the previous goals has been backdated out of that current week.

---

### **Available Endpoints**

--- List endpoints if any that was created using the following format

#### **PUT** `/api/v1/goal/back-date`

Description of what the endpoint does

**Sample Response:**
```json
{
  "endpoint_response": {
      "status": "success",
      "message": "All created goals during the current week were successfully back-dated",
      "data": null
    }
}
```